### PR TITLE
De-boilerplate the model directives

### DIFF
--- a/planning/test/planning_test_helpers.cc
+++ b/planning/test/planning_test_helpers.cc
@@ -30,6 +30,13 @@ std::unique_ptr<RobotDiagram<double>> MakePlanningTestModel(
   return builder->Build();
 }
 
+std::unique_ptr<RobotDiagram<double>> MakePlanningTestModel(
+    const std::string& model_ext, const std::string& model_contents) {
+  auto builder = std::make_unique<RobotDiagramBuilder<double>>();
+  builder->parser().AddModelsFromString(model_contents, model_ext);
+  return builder->Build();
+}
+
 Eigen::VectorXd GetIiwaDistanceWeights() {
   Eigen::VectorXd weights = Eigen::VectorXd::Zero(7);
   weights << 2.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0;

--- a/planning/test/planning_test_helpers.h
+++ b/planning/test/planning_test_helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "drake/multibody/parsing/model_directives.h"
 #include "drake/planning/collision_checker.h"
@@ -13,6 +14,12 @@ namespace test {
 /* Creates a RobotDiagram from the given directives. */
 std::unique_ptr<RobotDiagram<double>> MakePlanningTestModel(
     const multibody::parsing::ModelDirectives& directives);
+
+/* Creates a RobotDiagram from the given model data string.
+The model_ext is the file format extension (e.g., "dmd.yaml").
+The model_data is the model file contents. */
+std::unique_ptr<RobotDiagram<double>> MakePlanningTestModel(
+    const std::string& model_ext, const std::string& model_contents);
 
 /* Returns a vector of non-uniform distance weights for a 7-dof iiwa. */
 Eigen::VectorXd GetIiwaDistanceWeights();


### PR DESCRIPTION
This better highlights the important semantic content, instead of the C++ boilerplate.